### PR TITLE
Update grailbio/base in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
-	github.com/grailbio/base v0.0.6
+	github.com/grailbio/base v0.0.9
 	github.com/grailbio/hts v1.0.2-0.20200303061016-030e6b9f995e
 	github.com/grailbio/testutil v0.0.3
 	github.com/klauspost/compress v1.8.6


### PR DESCRIPTION
The old version of grailbio/base (0.0.6) points to a v.io/v23 module with an
invalid go version.  This revision changes the grailbio/base version to 0.0.9
which points to a valid v.io/v23 module.